### PR TITLE
Fix a memory leak

### DIFF
--- a/src/FTGlyph/FTPixmapGlyph.cpp
+++ b/src/FTGlyph/FTPixmapGlyph.cpp
@@ -54,6 +54,7 @@ FTGlyphImpl *FTPixmapGlyph::NewImpl(FT_GlyphSlot glyph)
   FTPixmapGlyphImpl *Impl = new FTPixmapGlyphImpl(glyph);
   if (Impl->destWidth && Impl->destHeight)
     return Impl;
+  delete Impl;
   return new FTBitmapGlyphImpl(glyph);
 }
 


### PR DESCRIPTION
I would have preferred using c++14 with std::make_unique and std::unique_ptr to fix this but if it is to be merged upstream, maybe the compatibility with old c++ is needed, so I just use a delete.