### PR TITLE
Fixing issue with setting character resolution

### DIFF
--- a/src/FTSize.cpp
+++ b/src/FTSize.cpp
@@ -46,7 +46,7 @@ bool FTSize::CharSize(FT_Face* face, unsigned int pointSize, unsigned int xRes, 
 {
     if(size != pointSize || xResolution != xRes || yResolution != yRes)
     {
-        err = FT_Set_Char_Size(*face, 0L, pointSize * 64, xResolution, yResolution);
+        err = FT_Set_Char_Size(*face, 0L, pointSize * 64, xRes, yRes);
 
         if(!err)
         {


### PR DESCRIPTION
The X resolution and the Y resolution were being updated from the cached values instead of the new values. FT_Set_Char_Size was also called before the cached values were updated with the new values.